### PR TITLE
Update CCSegStatTest

### DIFF
--- a/CCSegStatTest
+++ b/CCSegStatTest
@@ -354,7 +354,7 @@ def main():
 
 
 	groupFileFID = open(groupFile, 'r')
-	groupFileReader = csv.reader(groupFileFID, delimiter = "\t")
+	groupFileReader = csv.reader(groupFileFID, delimiter = ",") 
 	
 	groupLabels = list()
 	groupLists = dict()


### PR DESCRIPTION
replaced delimiter in groupFile with "," as "\t"

as "\t" didn't  worked  and  difficult to create groupFile with "\t" as delimiter 
"," comma separated groupFile is easy n useful to create and maintain ....